### PR TITLE
modular no-temp swap

### DIFF
--- a/src/bubble.js
+++ b/src/bubble.js
@@ -1,10 +1,15 @@
+/**
+Swaps 2 indices within array (in-place).
+*/
+const swap = (arr, i, j) => {
+  [arr[i], arr[j]] = [arr[j], arr[i]];
+};
+
 export function bubbleSort(arr) {
   for (let i = 0; i < arr.length; i++) {
     for (let j = 0; j < arr.length - i - 1; j++) {
       if (arr[j] > arr[j + 1]) {
-        let temp = arr[j];
-        arr[j] = arr[j + 1];
-        arr[j + 1] = temp;
+        swap(arr, j, j + 1);
       }
     }
   }


### PR DESCRIPTION
This uses destructuring syntax, to avoid the potential confusion of temporary vars. It also defines a `swap` fn that mutates whatever array is passed as input, without returning it.

A more functional approach would be to shallow-copy the array, mutate the copy, then return it. Should we do that instead?

BTW, `let temp` can be replaced by `const temp` (#3 closes it)